### PR TITLE
added n_features_in_ to three of the embedded class estimators

### DIFF
--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -78,6 +78,8 @@ class AdjacencySpectralEmbed(BaseEmbed):
 
     Attributes
     ----------
+    n_features_in_: int
+        number of features passed to the fit method.
     latent_left_ : array, shape (n_samples, n_components)
         Estimated left latent positions of the graph.
     latent_right_ : array, shape (n_samples, n_components), or None
@@ -158,6 +160,6 @@ class AdjacencySpectralEmbed(BaseEmbed):
 
         if self.diag_aug:
             A = augment_diagonal(A)
-
+        self.n_features_in_ = len(A)
         self._reduce_dim(A)
         return self

--- a/graspy/embed/base.py
+++ b/graspy/embed/base.py
@@ -58,6 +58,8 @@ class BaseEmbed(BaseEstimator):
     ----------
     n_components_ : int
         Dimensionality of the embedded space.
+    n_features_in_: int
+        number of features passed to the fit method.
 
     See Also
     --------

--- a/graspy/embed/lse.py
+++ b/graspy/embed/lse.py
@@ -73,6 +73,8 @@ class LaplacianSpectralEmbed(BaseEmbed):
 
     Attributes
     ----------
+    n_features_in_: int
+        number of features passed to the fit method.
     latent_left_ : array, shape (n_samples, n_components)
         Estimated left latent positions of the graph.
 
@@ -162,6 +164,7 @@ class LaplacianSpectralEmbed(BaseEmbed):
                 )
                 warnings.warn(msg, UserWarning)
 
+        self.n_features_in_ = len(A)
         L_norm = to_laplace(A, form=self.form, regularizer=self.regularizer)
         self._reduce_dim(L_norm)
         return self

--- a/graspy/embed/mds.py
+++ b/graspy/embed/mds.py
@@ -71,6 +71,9 @@ class ClassicalMDS(BaseEstimator):
         Equals the parameter n_components. If input n_components was None,
         then equals the optimal embedding dimension.
 
+    n_features_in_: int, or array, shape(1, 2)
+        number of features passed to the fit method.
+
     components_ : array, shape (n_components, n_features)
         Principal axes in feature space.
 
@@ -203,6 +206,10 @@ class ClassicalMDS(BaseEstimator):
         self.components_ = U
         self.singular_values_ = D ** 0.5
         self.dissimilarity_matrix_ = dissimilarity_matrix
+        if X.ndim == 2:
+            self.n_features_in_ = X.shape[1]
+        else:
+            self.n_features_in_ = X.shape[1,2]
 
         return self
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/neurodata/graspy/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #354.


#### What does this implement/fix? Explain your changes.
Added n_features_in_ to three embedded class estimators, ase.py, lse.py, and mds.py
For ase and lse, the n_features_in_ attribute equals to the number of points in the graph. And for mds, the attribute equals to the number of features of each sample.
#### Any other comments?

